### PR TITLE
evm-types.md: add constraint on sizeWordStack

### DIFF
--- a/evm-types.md
+++ b/evm-types.md
@@ -415,6 +415,7 @@ A cons-list is used for the EVM wordstack.
  // ----------------------------------------------------------------------------------------------------------------------------
     rule #sizeWordStack ( .WordStack ) => 0
     rule #sizeWordStack ( W : WS )     => #sizeWordStack(WS) +Int 1
+    rule #sizeWordStack ( WS ) >=Int 0 => true [smt-lemma]
 
     syntax Bool ::= Int "in" WordStack [function]
  // ---------------------------------------------


### PR DESCRIPTION
rather than having it in [`rules.k.tmpl`](https://github.com/dapphub/klab/blob/master/resources/rules.k.tmpl), cf. https://github.com/dapphub/klab/pull/355.